### PR TITLE
[feat] toml configuration file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nhdl"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,15 +6,30 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "~2.27.0", features = ["yaml"] }
 futures = "0.3.19"
 image = "0.23.14"
 regex = "1.5.4"
-reqwest = { version = "0.11.8", features = ["blocking"] }
 select = "0.5.0"
 textwrap = "0.14.2"
-tokio = { version = "1.15.0", features = ["full"] }
 toml = "0.5"
 tracing = "0.1.29"
 tracing-futures = "0.2.5"
 tracing-subscriber = "0.3.4"
+
+[dependencies.clap]
+version = "~2.27.0"
+features = [
+    "yaml"
+]
+
+[dependencies.reqwest]
+version = "0.11.8"
+features = [
+    "blocking"
+]
+
+[dependencies.tokio]
+version = "1.15.0"
+features = [
+    "full"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 [dependencies]
 futures = "0.3.19"
 image = "0.23.14"
+lazy_static = "1.4"
 regex = "1.5.4"
 select = "0.5.0"
 textwrap = "0.14.2"
@@ -32,4 +33,10 @@ features = [
 version = "1.15.0"
 features = [
     "full"
+]
+
+[dependencies.serde]
+version = "1.0.133"
+features = [
+    "derive"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,9 @@ version = "1.0.133"
 features = [
     "derive"
 ]
+
+[dependencies.config]
+version = "0.11"
+features = [
+    "toml"
+]

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+path = './'
+proxy = ''
+proxy_username = ''
+proxy_password = ''

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -18,6 +18,8 @@ use reqwest::Client;
 
 use tracing::error;
 
+use crate::CONFIG;
+
 pub async fn downloader(paths: Vec<String>, id: String, client: Client) {
     let sem = Arc::new(Semaphore::new(10)); // limit max amount of threads so downloads don't break
     let mut tasks: Vec<JoinHandle<Result<(), ()>>> = vec![]; // initialize empty vector for list of tasks
@@ -37,7 +39,7 @@ pub async fn downloader(paths: Vec<String>, id: String, client: Client) {
                             let page_re = Regex::new(r"(\w+\.)+\w+$").unwrap();
                             let page_caps = page_re.captures(&path).unwrap();
                             let file_name = page_caps.get(0).map_or("", |m| m.as_str());
-                            img.save(format!("{}/{}", id, file_name)).unwrap();
+                            img.save(format!("{}{}/{}", CONFIG.path, id, file_name)).unwrap();
                         },
                         Err(e) => error!("cannot write file: {:?}", e)
                     },             

--- a/src/init.rs
+++ b/src/init.rs
@@ -17,7 +17,7 @@ use tracing::error;
 
 fn init_cli() -> clap::Result<ArgMatches<'static>> { 
     return App::new("nhdl")
-        .version("0.1.3")
+        .version("0.1.4")
         .author("j1nxie (rylieeeeexd@gmail.com)")
         .arg(Arg::with_name("INPUT")
             .help("nhentai id / url")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,0 +1,28 @@
+use config::{
+    Config,
+    ConfigError,
+    Environment,
+    File,
+};
+
+use serde::Deserialize;
+
+const CONFIG_FILE_PATH: &str = "./config.toml";
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct Settings {
+    pub path: String,
+    pub proxy: String,
+    pub proxy_username: String,
+    pub proxy_password: String,
+}
+
+impl Settings {
+    pub fn new() -> Result<Self, ConfigError> {
+        let mut s = Config::new();
+        s.merge(File::with_name(CONFIG_FILE_PATH))?;
+        s.merge(Environment::with_prefix("nhdl").separator("__"))?;
+        
+        s.try_into()
+    }
+}


### PR DESCRIPTION
toml configuration added, with path and proxy support. proxy support is currently untested. config file is loaded as \``config.toml`\`, located in cwd. an example file is included for \``cargo run`\`.